### PR TITLE
pprint is in the stdlib

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     zip_safe=False,
     install_requires=[
         "alooma>=0.4.15",
-        "pprint>=0.1",
         "requests>=2.21.0",
         "tabulate>=0.8.3",
         "pandas>=0.23.4",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='managealooma',
-    version='0.1.13',
+    version='0.1.14',
     author='Jay Rosenthal',
     author_email='jay.rosenthal@hover.to',
     packages=['managealooma'],


### PR DESCRIPTION
Pprint is in the stdlib, so it should not be in the requirements list. This is breaking our internal tool.